### PR TITLE
Only disable EXTI controller if all callbacks for it are detached

### DIFF
--- a/cores/arduino/libstm32f1/interrupt.c
+++ b/cores/arduino/libstm32f1/interrupt.c
@@ -209,6 +209,15 @@ void stm32_interrupt_enable(GPIO_TypeDef *port, uint16_t pin,
 void stm32_interrupt_disable(GPIO_TypeDef *port, uint16_t pin)
 {
   uint8_t id = get_pin_id(pin);
+  
+  gpio_irq_conf[id].callback = NULL;
+  
+  for(int i = 0; i < NB_EXTI; i++) {
+    if (gpio_irq_conf[id].irqnb == gpio_irq_conf[i].irqnb 
+        && gpio_irq_conf[i].callback != NULL) {
+      return;
+    }
+  }
   HAL_NVIC_DisableIRQ(gpio_irq_conf[id].irqnb);
 }
 


### PR DESCRIPTION
The following code fails to register interrupts on `PB8`, because `detachInterrupt(PB7);` disables `EXTI9_5_IRQn`, and `PB8` is also on that.:
```
void interrupt() {
  digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
}

void setup() {
  pinMode(LED_BUILTIN, OUTPUT);
  attachInterrupt(PB8, interrupt, LOW);
  attachInterrupt(PB7, interrupt, LOW);
  detachInterrupt(PB7);
}

void loop() {
  
}
```