### PR TITLE
Fix analogRead() for non-nucleo boards

### DIFF
--- a/cores/arduino/libstm32f1/analog.c
+++ b/cores/arduino/libstm32f1/analog.c
@@ -592,6 +592,10 @@ uint16_t adc_read_value(GPIO_TypeDef  *port, uint32_t pin, uint8_t do_init)
   __IO uint16_t uhADCxConvertedValue = 0;
 
   AdcHandle.Instance = g_analog_init_config[id].adcInstance;
+  
+  if (AdcHandle.Instance == NULL) {
+      return 0;
+  }
 
   if(do_init == 1) {
 

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -45,13 +45,7 @@ static inline int32_t get_pin_description(uint32_t apin, uint32_t ulPin)
   return -1;
 }
 
-static inline int32_t pinConvert(uint32_t ulPin)
-{
-  if(ulPin < ARDUINO_PIN_A0)
-    return ulPin | ARDUINO_PIN_A0;
-  else
-    return ulPin;
-}
+uint32_t analogPinConvert(uint32_t ulPin) __attribute__((weak));
 
 
 void analogReadResolution(int res) {
@@ -87,7 +81,9 @@ uint32_t analogRead(uint32_t ulPin)
     return 0;
   }
 
-  ulPin = pinConvert(ulPin);
+  if (analogPinConvert) {
+    ulPin = analogPinConvert(ulPin);
+  }
 
   //find the pin.
   i = get_pin_description(apin, ulPin);

--- a/variants/STM32F103RB_Nucleo/variant.cpp
+++ b/variants/STM32F103RB_Nucleo/variant.cpp
@@ -190,6 +190,12 @@ void SystemClock_Config(void)
   
 void __libc_init_array(void);
 
+uint32_t analogPinConvert(uint32_t ulPin) {
+  if(ulPin < ARDUINO_PIN_A0) 
+    return ulPin | ARDUINO_PIN_A0; 
+  else 
+    return ulPin;
+}
 
 void init( void )
 {


### PR DESCRIPTION
Moves the pinConvert (renamed to analogPinConvert) to nucleo variant only.
With this, for example analogRead(PA0) will work, and analogRead(PB10) will not crash.
